### PR TITLE
一些翻译的问题，建议根据需求选择性merge

### DIFF
--- a/docs/reference/properties.md
+++ b/docs/reference/properties.md
@@ -2,10 +2,10 @@
 type: doc
 layout: reference
 category: "Syntax"
-title: "属性(Property)与域(Field)"
+title: "属性(Property)与字段(Field)"
 ---
 
-# 属性(Property)与域(Field)
+# 属性(Property)与字段(Field)
 
 ## 声明属性
 
@@ -21,7 +21,7 @@ public class Address {
 }
 ```
 
-使用属性时, 只需要简单地通过属性名来参照它, 和使用 Java 中的域变量(field)一样:
+使用属性时, 只需要简单地通过属性名来参照它, 和使用 Java 中的字段变量(field)一样:
 
 ``` kotlin
 fun copyAddress(address: Address): Address {
@@ -33,7 +33,7 @@ fun copyAddress(address: Address): Address {
 }
 ```
 
-## 取值方法(Getter)与设值方法(Setter)
+## Getter 和 Setter
 
 声明属性的完整语法是:
 
@@ -43,30 +43,30 @@ var <propertyName>: <PropertyType> [= <property_initializer>]
     [<setter>]
 ```
 
-其中的初始化器(initializer), 取值方法(getter), 以及设值方法(setter)都是可选的. 如果属性类型可以通过初始化器自动推断得到, 或者可以通过这个属性覆盖的基类成员属性推断得到, 则属性类型的声明也可以省略.
+其中的initializer, getter, 以及 setter 都是可选的. 如果属性的类型可以通过 initializer 自动推断得到, 或者可以通过这个属性重载的基类成员属性推断得到, 则属性的类型声明也可以省略.
 
 示例:
 
 ``` kotlin
-var allByDefault: Int? // 错误: 需要明确指定初始化器, 此处会隐含地使用默认的取值方法和设值方法
-var initialized = 1 // 属性类型为 Int, 使用默认的取值方法和设值方法
+var allByDefault: Int? // 错误: 需要明确指定 initializer, 此处会隐含地使用默认的 getter 和 setter
+var initialized = 1 // 属性类型为 Int, 使用默认的 getter 和 setter
 ```
 
-只读属性声明的完整语法与可变属性有两点不同: 由 `val` 开头, 而不是 `var`, 并且不允许指定设值方法:
+只读属性（常量）声明的完整语法与可变属性有两点不同: 由 `val` 开头, 而不是 `var`, 并且不允许指定 setter :
 
 ``` kotlin
-val simple: Int? // 属性类型为 Int, 使用默认的取值方法, 属性值必须在构造器中初始化
-val inferredType = 1 // 属性类型为 Int, 使用默认的取值方法
+val simple: Int? // 属性类型为 Int, 使用默认的 getter, 属性值必须在构造器中初始化
+val inferredType = 1 // 属性类型为 Int, 使用默认的 getter
 ```
 
-我们可以编写自定义的访问方法, 与普通的函数很类似, 访问方法的位置就在属性定义体之内. 下面是一个自定义取值方法的示例:
+我们可以编写自定义的访问方法, 与普通的函数很类似, 访问方法的位置就在属性定义体之内. 下面是一个自定义 getter 的示例:
 
 ``` kotlin
 val isEmpty: Boolean
     get() = this.size == 0
 ```
 
-自定义设值方法的示例如下:
+自定义 setter 的示例如下:
 
 ``` kotlin
 var stringRepresentation: String
@@ -76,24 +76,25 @@ var stringRepresentation: String
     }
 ```
 
-Kotlin 的编程惯例是, 设值方法的参数名称为 `value`, 但如果你喜欢, 也可以选择使用不同的名称.
+Kotlin 的编程惯例是,  setter 的参数名称为 `value`, 但如果你喜欢, 也可以选择使用不同的名称.
 
 如果你需要改变属性访问方法的可见度, 或者需要对其添加注解, 但又不需要修改它的默认实现, 你可以定义这个方法, 但不定义它的实现体:
 
 ``` kotlin
 var setterVisibility: String = "abc"
-    private set // 设值方法的可见度为 private, 并使用默认实现
+    private set //  setter 的可见度为 private, 并使用默认实现
 
 var setterWithAnnotation: Any? = null
-    @Inject set // 对设值方法添加 Inject 注解
+    @Inject set // 对 setter 添加 Inject 注解
 ```
 
-### 属性的后端域变量(Backing Field)
+### 属性的备份字段(Backing Field)
 
-Kotlin 的类不能拥有域变量. 但是, 使用属性的自定义访问器时, 有时会需要后端域变量(backing field). 为了这种目的, Kotlin 提供了一种自动的后端域变量, 可以通过 `field` 标识符来访问:
+Kotlin 的类不能拥有字段. 但是, 使用属性的自定义访问器时, 有时会需要备份字段(backing field).
+为了这种目的, Kotlin 提供了一种自动生成的备份字段, 可以通过 `field` 标识符来访问:
 
 ``` kotlin
-var counter = 0 // 初始化给定的值将直接写入后端域变量中
+var counter = 0 // 初始化给定的值将直接写入备份字段中
     set(value) {
         if (value >= 0) field = value
     }
@@ -102,18 +103,18 @@ var counter = 0 // 初始化给定的值将直接写入后端域变量中
 
 `field` 标识符只允许在属性的访问器函数内使用.
 
-如果属性 get/set 方法中的任何一个使用了默认实现, 或者在 get/set 方法的自定义实现中通过 `field` 标识符访问属性, 那么编译器就会为属性自动生成后端域变量.
+如果属性 get/set 方法中的任何一个使用了默认实现, 或者在 get/set 方法的自定义实现中通过 `field` 标识符访问属性, 那么编译器就会为属性自动生成备份字段.
 
-比如, 下面的情况不会存在后端域变量:
+比如, 下面的情况不会存在备份字段:
 
 ``` kotlin
 val isEmpty: Boolean
     get() = this.size == 0
 ```
 
-### 后端属性(Backing Property)
+### 备份属性(Backing Property)
 
-如果你希望实现的功能无法通过这种 "隐含的后端域变量" 方案来解决, 你可以使用 *后端属性(backing property)* 作为替代方案:
+如果你希望实现的功能无法通过这种 "隐含的备份字段" 方案来解决, 你可以使用 *备份属性(backing property)* 作为替代方案:
 
 ``` kotlin
 private var _table: Map<String, Int>? = null
@@ -126,17 +127,18 @@ public val table: Map<String, Int>
     }
 ```
 
-不管从哪方面看, 这种方案都与 Java 中完全相同, 因为后端私有属性的取值方法与设值方法都使用默认实现, 我们对这个属性的访问将被编译器优化, 变为直接读写后端域变量, 因此不会发生不必要的函数调用, 导致性能损失.
+不管从哪方面看, 这种方案都与 Java 中完全相同, 因为私有的备份属性的 getter 与 setter 都使用默认实现,
+我们对这个属性的访问将被编译器优化, 变为直接读写备份字段, 因此不会发生不必要的函数调用, 导致性能损失.
 
 
-## 编译期常数值
+## 编译期常量
 
-如果属性值在编译期间就能确定, 则可以使用 `const` 修饰符, 将属性标记为_编译期常数值(compile time constants)_.
+如果属性值在编译期间就能确定, 则可以使用 `const` 修饰符, 将属性标记为_编译期常量(compile time constants)_.
 这类属性必须满足以下所有条件:
 
-  * 必须是顶级属性, 或者是一个 `object` 的成员
-  * 值被初始化为 `String` 类型, 或基本类型(primitive type)
-  * 不存在自定义的取值方法
+  * 必须是顶级属性（即直接写在文件里面的）, 或者是一个 `object` 的成员
+  * 值被初始化为 `String` 类型, 或值类型(primitive type)
+  * 不存在自定义的 getter
 
 这类属性可以用在注解内:
 
@@ -149,7 +151,8 @@ const val SUBSYSTEM_DEPRECATED: String = "This subsystem is deprecated"
 
 ## 延迟初始化属性(Late-Initialized Property)
 
-通常, 如果属性声明为非 null 数据类型, 那么属性值必须在构造器内初始化. 但是, 这种限制很多时候会带来一些不便. 比如, 属性值可以通过依赖注入来进行初始化, 或者在单元测试代码的 setup 方法中初始化. 这种情况下, 你就无法在构造器中为属性编写一段非 null 值的初始化代码, 但你仍然希望在类内参照这个属性时能够避免 null 值检查.
+通常, 如果属性声明为非 null 数据类型, 那么属性值必须在构造器内初始化. 但是, 这种限制很多时候会带来一些不便.
+比如, 属性值可以通过依赖注入来进行初始化, 或者在单元测试代码的 setup 方法中初始化. 这种情况下, 你就无法在构造器中为属性编写一段非 null 值的初始化代码, 但你仍然希望在类内参照这个属性时能够避免 null 值检查.
 
 要解决这个问题, 你可以为属性添加一个 `lateinit` 修饰符:
 
@@ -167,16 +170,17 @@ public class MyTest {
 }
 ```
 
-这个修饰符只能用于 `var` 属性, 而且只能是声明在类主体部分之内的属性(不可以是主构造器中声明的属性), 而且属性不能有自定义的取值方法和设值方法. 属性类型必须是非 null 的, 而且不能是基本类型.
+这个修饰符只能用于 `var` 属性, 而且只能是声明在类主体部分之内的属性(不可以是主构造器中声明的属性), 而且属性不能有自定义的 getter和 setter. 属性类型必须是非 null 的, 而且不能是值类型.
 
 在一个 `lateinit` 属性被初始化之前访问它, 会抛出一个特别的异常, 这个异常将会指明被访问的属性, 以及它没有被初始化这一错误.
 
-## 属性的覆盖
+## 属性的重载
 
-参见 [属性的覆盖](classes.html#overriding-properties)
+参见 [属性的重载](classes.html#overriding-properties)
 
 ## 委托属性(Delegated Property)
   
-最常见的属性只是简单地读取(也有可能会写入)一个后端域变量. 但是, 通过使用自定义的取值方法和设值方法, 我们可以实现属性任意复杂的行为. 在这两种极端情况之间, 还存在一些非常常见的属性工作模式. 比如: 属性值的延迟加载, 通过指定的键值(key)从 map 中读取数据, 访问数据库, 属性被访问时通知监听器, 等等.
+最常见的属性只是简单地读取(也有可能会写入)一个备份字段. 但是, 通过使用自定义的 getter 和 setter, 我们可以实现属性任意复杂的行为.
+在这两种极端情况之间, 还存在一些非常常见的属性工作模式. 比如: 属性值的惰性求值, 通过指定的键值(key)从 map 中读取数据, 访问数据库, 属性被访问时通知监听器, 等等.
 
 这些常见行为可以使用[_委托属性(delegated property)_](delegated-properties.html), 以库的形式实现.

--- a/docs/reference/properties.md
+++ b/docs/reference/properties.md
@@ -43,7 +43,7 @@ var <propertyName>: <PropertyType> [= <property_initializer>]
     [<setter>]
 ```
 
-其中的initializer, getter, 以及 setter 都是可选的. 如果属性的类型可以通过 initializer 自动推断得到, 或者可以通过这个属性重载的基类成员属性推断得到, 则属性的类型声明也可以省略.
+其中的initializer, getter, 以及 setter 都是可选的. 如果属性的类型可以通过 initializer 自动推断得到, 或者可以通过这个属性覆盖的基类成员属性推断得到, 则属性的类型声明也可以省略.
 
 示例:
 
@@ -174,9 +174,9 @@ public class MyTest {
 
 在一个 `lateinit` 属性被初始化之前访问它, 会抛出一个特别的异常, 这个异常将会指明被访问的属性, 以及它没有被初始化这一错误.
 
-## 属性的重载
+## 属性的覆盖
 
-参见 [属性的重载](classes.html#overriding-properties)
+参见 [属性的覆盖](classes.html#overriding-properties)
 
 ## 委托属性(Delegated Property)
   


### PR DESCRIPTION
修正：

## 域 -> 字段

我通过[谷歌翻译：字段](https://translate.google.com/?um=1&ie=UTF-8&hl=zh-CN&client=tw-ob#auto/en/%E5%AD%97%E6%AE%B5)证明我的翻译是正确的。

事实上，*字段*对应的才是Java中的字段概念，而*域*是指数学上的域，比如定义域、值域等（也不是作用域，作用域是scope）。**这里是明显的翻译不恰当。**

## 后端变量 -> 备份变量

首先，*backing field*是Java没有的概念，用于表示属性对应的字段变量。

*备份*的英语是back up，而*后端*是back-end。考虑到*后端*这一词语本身总是对应着*前端*，而这里又没有*前端*变量，因此建议翻译为*备份*变量。**这里只是建议。**

## 延迟加载 -> 惰性求值

因为Haskell程序员都称之为惰性求值。可以参考[Wikipedia](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=3&cad=rja&uact=8&ved=0ahUKEwibt6zA-IrTAhUD8GMKHeY2B88QFggkMAI&url=https%3A%2F%2Fzh.wikipedia.org%2Fzh-hans%2F%25E6%2583%25B0%25E6%2580%25A7%25E6%25B1%2582%25E5%2580%25BC&usg=AFQjCNGYwGPQcFD4mn_2AOGNTtUNU2ziww&sig2=U8TP7TlwyR1yGsFZV_jLMQ)，这里的Lazy Evaluation明显对应的是同一概念。不要跟我说你没听说过函数式编程。**此处是明显的翻译不恰当。**

## 取值方法 -> getter

这个概念，根据我平时混迹技术社区的经验，一般Java程序员都直接称之为getter，英语再差的程序员也称之为getter，目前我还没有听到谁称之为*取值方法*。因此，**非常建议修改。**

## 设值方法 -> setter

同上，**非常建议修改。**

## 其他

基本就这些，剩下一些不足挂齿的small fixes。

我只是做了一些微小的工作。很惭愧。